### PR TITLE
Fix missing bold font

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -12,7 +12,7 @@ export const ibmPlexSans = IBM_Plex_Sans({
   subsets: ['latin'],
   variable: '--font-main',
   display: 'swap',
-  weight: ['400'],
+  weight: ['400', '700'],
   style: ['normal', 'italic'],
 });
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "prettier": "^3.0.3",
     "sass": "^1.69.2",
     "stylelint": "^15.10.0",
-    "stylelint-config-prettier": "^9.0.0",
     "stylelint-config-standard-scss": "^11.0.0",
     "stylelint-declaration-strict-value": "^1.4.3",
     "typescript": "^5.2.2"

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: ['stylelint-declaration-strict-value'],
-  extends: ['stylelint-config-standard-scss', 'stylelint-config-prettier'],
+  extends: ['stylelint-config-standard-scss'],
   rules: {
     'declaration-no-important': true,
     'selector-max-id': 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4622,11 +4622,6 @@ styled-jsx@5.1.1:
   dependencies:
     client-only "0.0.1"
 
-stylelint-config-prettier@^9.0.0:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz#9f78bbf31c7307ca2df2dd60f42c7014ee9da56e"
-  integrity sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==
-
 stylelint-config-recommended-scss@^13.0.0:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-13.0.0.tgz#dd8c319e15a6412262cd8554e4aad9bfba1bbb11"


### PR DESCRIPTION
While using the production site, I noticed that much of the text was blurry/antialiased. Upon inspection, I saw that `<strong>` tags were in use, but the bold font weight was not being served for IBM Plex, leading to the blurry rendering.

This PR adds that font into the build, and also removes the `stylelint-config-pretter` dependency (due to deprecation and an installation conflict when I was attempting to set up the repository).